### PR TITLE
Attempted to add Third sample upgrade

### DIFF
--- a/GameData/Kerbalism/System/ScienceRework/Groups/Upgrades.cfg
+++ b/GameData/Kerbalism/System/ScienceRework/Groups/Upgrades.cfg
@@ -209,6 +209,19 @@ PARTUPGRADE:NEEDS[FeatureScience]
   %techRequired = #$@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/SecondUpgradeTech$
   %entryCost = #$@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/SecondUpgradeEntryCost$
 }
+PARTUPGRADE:NEEDS[FeatureScience]
+{
+  name = SampleCapacity-Upgrade3
+  partIcon = ScienceBox
+  title = Sample Storage Capacity Upgrade
+  manufacturer = Spacegate Technology
+  description = Increase the total amount of sample storage
+}
+@PARTUPGRADE[SampleCapacity-Upgrade3]:NEEDS[FeatureScience]:FOR[Kerbalism]
+{
+  %techRequired = #$@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/ThirdUpgradeTech$
+  %entryCost = #$@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/ThirdUpgradeEntryCost$
+}
 
 //=========================================================
 // Misc

--- a/GameData/Kerbalism/System/ScienceRework/HardDriveConfigs.cfg
+++ b/GameData/Kerbalism/System/ScienceRework/HardDriveConfigs.cfg
@@ -380,8 +380,7 @@
 		}
 	}
 }		
-	
-@PART[*]:HAS[@MODULE[HardDrive]:HAS[#sampleCapacity[>8],~experiment_id]]:NEEDS[FeatureScience]:FOR[zzzKerbalism]
+@PART[*]:HAS[@MODULE[HardDrive]:HAS[#sampleCapacity[>5],~experiment_id]]:NEEDS[FeatureScience]:FOR[zzzKerbalism]
 {
 	@MODULE[HardDrive]
 	{
@@ -393,6 +392,22 @@
 				techRequired__ = #$../../../@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/SecondUpgradeTech$
 				sampleCapacity = #$../../#sampleCapacity$
 				@sampleCapacity *= #$../../../@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/SecondUpgrade$
+			}
+		}
+	}
+}	
+@PART[*]:HAS[@MODULE[HardDrive]:HAS[#sampleCapacity[>8],~experiment_id]]:NEEDS[FeatureScience]:FOR[zzzKerbalism]
+{
+	@MODULE[HardDrive]
+	{
+		%UPGRADES
+		{			
+			UPGRADE
+			{
+				name__ = SampleCapacity-Upgrade3
+				techRequired__ = #$../../../@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/ThirdUpgradeTech$
+				sampleCapacity = #$../../#sampleCapacity$
+				@sampleCapacity *= #$../../../@KERBALISM_HDD_SIZES/Upgrades/SAMPLE_CAPACITY_MULTIPLIERS/ThirdUpgrade$
 			}
 		}
 	}

--- a/GameData/Kerbalism/System/ScienceRework/Tweakables/StockHardDrives.cfg
+++ b/GameData/Kerbalism/System/ScienceRework/Tweakables/StockHardDrives.cfg
@@ -48,9 +48,12 @@
 			FirstUpgrade = 3
 			FirstUpgradeTech = miniaturization
 			FirstUpgradeEntryCost = 12500
-			SecondUpgrade = 12
-			SecondUpgradeTech = fieldScience
+			SecondUpgrade = 6
+			SecondUpgradeTech = advancedExploration
 			SecondUpgradeEntryCost = 25000
+			ThirdUpgrade = 12
+			ThirdUpgradeTech = fieldScience
+			ThirdUpgradeEntryCost = 35000
 		}
 	}
 
@@ -107,7 +110,7 @@
 		MK2Pod											//T4
 		{
 			data = 11.33
-			samples = 3
+			samples = 4
 		}
 
 		OKTO											//T4
@@ -116,10 +119,10 @@
 			samples = 0
 		}
 
-		MK1-3Pod										//T5
+		MK1-3Pod										//T6
 		{
 			data = 32.53
-			samples = 4
+			samples = 6
 		}
 
 		MK2Cockpit										//T5
@@ -179,7 +182,7 @@
 		RoveMate										//T6
 		{
 			data = 118.51
-			samples = 8									//only probe that can store samples?
+			samples = 6									//only probe that can store samples?
 		}
 
 		MK2DroneCore									//T7


### PR DESCRIPTION
Made changes in Stockharddrives,harddriveconfigs and upgrades files but it doesn't show up in the tech tree. Modified a few stock vessel sample storages to account for mistaken tier placement