### PR TITLE
Fixed the second sample upgrade

### DIFF
--- a/GameData/Kerbalism/System/ScienceRework/Tweakables/StockHardDrives.cfg
+++ b/GameData/Kerbalism/System/ScienceRework/Tweakables/StockHardDrives.cfg
@@ -49,7 +49,7 @@
 			FirstUpgradeTech = miniaturization
 			FirstUpgradeEntryCost = 12500
 			SecondUpgrade = 6
-			SecondUpgradeTech = advancedExploration
+			SecondUpgradeTech = advExploration
 			SecondUpgradeEntryCost = 25000
 			ThirdUpgrade = 12
 			ThirdUpgradeTech = fieldScience


### PR DESCRIPTION
Squad is super bad with tech node naming consistencies, everything else is by full name except for all advancedX nodes, this even has an exception though.